### PR TITLE
Fix compilation on 32-bit systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@
 #
 # Authors: Tim Stoakes <tim@stoakes.net>
 
-CFLAGS = -g -O2 -std=c99 -Wall -Werror -D_FILE_OFFSET_BITS=64
+CFLAGS = -g -O2 -std=c99 -D_FILE_OFFSET_BITS=64 \
+	 -Wall -Werror -Wno-error=pointer-to-int-cast -Wno-error=int-to-pointer-cast
 
 OBJS = notmuchfs.o
 


### PR DESCRIPTION
Compilation on 32-bit bombs out due to uint64_t not being the same size as a pointer:

```
cc -g -O2 -std=c99 -Wall -Werror -D_FILE_OFFSET_BITS=64   -c -MD -o notmuchfs.o notmuchfs.c
notmuchfs.c: In function ‘notmuchfs_opendir’:
notmuchfs.c:493:13: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
```

Of course storing pointers in a bigger integer is perfectly safe so we just have to make these warnings non-fatal.
