### PR TITLE
mutt: notmuch_tag: explicitly use bash

### DIFF
--- a/mutt/bin/notmuch_tag
+++ b/mutt/bin/notmuch_tag
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Script to prompt the user for the tag string to use (e.g. '+tag1 -tag2'),
 # then apply it to the given message(s).


### PR DESCRIPTION
Using #!/bin/sh is unsafe in notmuch_tag as it is filled with bash-isms.
In my environement /bin/sh symlinks to /bin/dash which doesn't play nice
with all of the syntax.

Fix by explicitly invoking bash.

Signed-off-by: Michael Turquette <mturquette@deferred.io>