### PR TITLE
Add a new delete_tag option

### DIFF
--- a/notmuchfs.c
+++ b/notmuchfs.c
@@ -1139,12 +1139,14 @@ static int notmuchfs_rename (const char* from, const char* to)
 
 static int notmuchfs_unlink (const char* path)
 {
+ /* Ignore the initial '/' */
  assert(path[0] == '/');
+ path++;
 
- char *last_pslash = strrchr(path + 1, '#');
+ char *last_pslash = strrchr(path, '#');
 
  if (last_pslash != NULL) {
-   char *last_slash = strrchr(path + 1, '/');
+   char *last_slash = strrchr(path, '/');
    char  trans_name[PATH_MAX];
 
    strncpy(trans_name, last_slash + 1, PATH_MAX - 1);
@@ -1173,8 +1175,8 @@ static int notmuchfs_unlink (const char* path)
    return 0;
  }
  else {
-   LOG_TRACE("unlink(%s)\n", path + 1);
-   if (unlink(path + 1) != 0)
+   LOG_TRACE("unlink(%s)\n", path);
+   if (unlink(path) != 0)
      return -errno;
    return 0;
  }

--- a/notmuchfs.c
+++ b/notmuchfs.c
@@ -89,6 +89,13 @@ struct notmuchfs_config {
    */
   char *mail_dir;
 
+
+  /**
+   * Tag to apply when a mail is deleted instead of the unlinking the
+   * underlying maildir file.
+   */
+  char *delete_tag;
+
   /**
    * Mutt is not compliant with the maildir spec, see:
    * - http://dev.mutt.org/trac/ticket/2476
@@ -1173,9 +1180,37 @@ static int notmuchfs_unlink (const char* path)
  database_close(p_ctx);
 #endif
 
- LOG_TRACE("unlink(%s)\n", path);
- if (unlink(path) != 0)
-   return -errno;
+ if (global_config.delete_tag) {
+   struct fuse_context *p_fuse_ctx = fuse_get_context();
+   notmuch_context_t    *p_ctx     =
+     (notmuch_context_t *)p_fuse_ctx->private_data;
+
+   database_open(p_ctx, TRUE);
+
+   LOG_TRACE("notmuch_database_find_message_by_filename(%s)\n", path);
+   notmuch_message_t *message;
+   notmuch_status_t status =
+     notmuch_database_find_message_by_filename(p_ctx->db, path, &message);
+   switch (status) {
+   case NOTMUCH_STATUS_SUCCESS:
+     break;
+   case NOTMUCH_STATUS_OUT_OF_MEMORY:
+     return -ENOMEM;
+   default:
+     return -EIO;
+   }
+
+   LOG_TRACE("notmuch_message_add_tag(%s, %s)\n", path,
+             global_config.delete_tag);
+   notmuch_message_add_tag(message, global_config.delete_tag);
+
+   database_close(p_ctx);
+ } else {
+   LOG_TRACE("unlink(%s)\n", path);
+   if (unlink(path) != 0)
+     return -errno;
+ }
+
  return 0;
 }
 
@@ -1242,6 +1277,7 @@ enum {
 static struct fuse_opt notmuchfs_opts[] = {
   NOTMUCHFS_OPT("backing_dir=%s",               backing_dir, 0),
   NOTMUCHFS_OPT("mail_dir=%s",                  mail_dir, 0),
+  NOTMUCHFS_OPT("delete_tag=%s",                delete_tag, 0),
   NOTMUCHFS_OPT("mutt_2476_workaround",         mutt_2476_workaround_allowed, 1),
   NOTMUCHFS_OPT("nomutt_2476_workaround",       mutt_2476_workaround_allowed, 0),
   NOTMUCHFS_OPT("--mutt_2476_workaround=true",  mutt_2476_workaround_allowed, 1),
@@ -1266,6 +1302,7 @@ static void print_notmuchfs_usage (char *arg0) {
           "Notmuchfs options:\n"
           "    -o backing_dir=PATH  Path to backing directory (required)\n"
           "    -o mail_dir=PATH     Path to parent directory of notmuch database (required)\n"
+          "    -o delete_tag=TAG    Tag to apply when a mail is deleted\n"
           "    -o mutt_2476_workaround\n"
           "    -o nomutt_2476_workaround (default)\n"
           , arg0);

--- a/notmuchfs.c
+++ b/notmuchfs.c
@@ -1139,6 +1139,8 @@ static int notmuchfs_rename (const char* from, const char* to)
 
 static int notmuchfs_unlink (const char* path)
 {
+ char trans_name[PATH_MAX];
+
  /* Ignore the initial '/' */
  assert(path[0] == '/');
  path++;
@@ -1147,39 +1149,34 @@ static int notmuchfs_unlink (const char* path)
 
  if (last_pslash != NULL) {
    char *last_slash = strrchr(path, '/');
-   char  trans_name[PATH_MAX];
 
    strncpy(trans_name, last_slash + 1, PATH_MAX - 1);
    trans_name[PATH_MAX - 1] = '\0';
    string_replace(trans_name, '#', '/');
 
+   path = trans_name;
+ }
+
 #if 0
-   /* Delete the message from the notmuch database too. Is this the right
-    * thing to do?
-    */
-   struct fuse_context *p_fuse_ctx = fuse_get_context();
-   notmuch_context_t    *p_ctx     =
-     (notmuch_context_t *)p_fuse_ctx->private_data;
+ /* Delete the message from the notmuch database too. Is this the right
+  * thing to do?
+  */
+ struct fuse_context *p_fuse_ctx = fuse_get_context();
+ notmuch_context_t    *p_ctx     =
+   (notmuch_context_t *)p_fuse_ctx->private_data;
 
-   database_open(p_ctx, TRUE);
+ database_open(p_ctx, TRUE);
 
-   LOG_TRACE("notmuch_database_remove_message(%s)\n", trans_name);
-   notmuch_database_remove_message(p_ctx->db, trans_name);
+ LOG_TRACE("notmuch_database_remove_message(%s)\n", path);
+ notmuch_database_remove_message(p_ctx->db, path);
 
-   database_close(p_ctx);
+ database_close(p_ctx);
 #endif
 
-   LOG_TRACE("unlink(%s)\n", trans_name);
-   if (unlink(trans_name) != 0)
-     return -errno;
-   return 0;
- }
- else {
-   LOG_TRACE("unlink(%s)\n", path);
-   if (unlink(path) != 0)
-     return -errno;
-   return 0;
- }
+ LOG_TRACE("unlink(%s)\n", path);
+ if (unlink(path) != 0)
+   return -errno;
+ return 0;
 }
 
 /*============================================================================*/


### PR DESCRIPTION
If this option is set then it specifies a notmuch tag that will be applied on unlink instead of unlinking the actual message file.  This, combined with the search.exclude_tags option allows for deleting mail from the fuse filesystem without actually losing any mail.

